### PR TITLE
Texture Set Selection for Create New Material

### DIFF
--- a/plugin/renderman_for_sp.py
+++ b/plugin/renderman_for_sp.py
@@ -650,24 +650,24 @@ class RenderManForSP(object):
                         ['Project settings'] + [str(2**x) for x in range(7, 14)])
                     lyt.addRow('Texture Resolution :', self.opt_resolution)
                     # texture sets to export
-                    mat_grp = QGroupBox()
-                    mat_grp.setCheckable(False)
+                    mat_grp = QWidget()
                     mat_lyt = QGridLayout()
                     mat_grp.setLayout(mat_lyt)
                     mat_lyt.setSpacing(5)
                     tsets = spts.all_texture_sets()
-                    self.opt_tsets = []
-                    for mat in tsets:
-                        mat_check = QCheckBox(mat.name())
-                        mat_check.setChecked(True)
-                        self.opt_tsets.append((mat_check, mat))
-                        mat_lyt.addWidget(mat_check)
+                    
                     checkBoxNone = QPushButton("Deselect All")
                     checkBoxNone.clicked.connect(self.deselctAllMaterials)
                     mat_lyt.addWidget(checkBoxNone, 0, 0)
                     checkBoxAll = QPushButton("Select All")
                     checkBoxAll.clicked.connect(self.selectAllMaterials)
                     mat_lyt.addWidget(checkBoxAll, 0, 1)
+                    self.opt_tsets = []
+                    for (i, mat) in enumerate(tsets):
+                        mat_check = QCheckBox(mat.name())
+                        mat_check.setChecked(True)
+                        self.opt_tsets.append((mat_check, mat))
+                        mat_lyt.addWidget(mat_check, i+1, 0, 1, 2)
                     mat_scroll = QScrollArea()
                     mat_scroll.setWidget(mat_grp)
                     mat_scroll.setWidgetResizable(True)

--- a/plugin/renderman_for_sp.py
+++ b/plugin/renderman_for_sp.py
@@ -353,6 +353,9 @@ class RenderManForSP(object):
                     # all texture sets who have a selected checkbox
                     tset_list = [matPair[1] for matPair in self.opt_tsets if matPair[0].checkState()] 
 
+                    if (len(tset_list) <= 0):
+                        LOG.info('RenderMan : No texture sets selected')
+                        return True
                     # build assets
                     for mat in tset_list:
                         if self.spx_progress.wasCanceled():
@@ -657,7 +660,7 @@ class RenderManForSP(object):
                         mat_check.setChecked(True)
                         self.opt_tsets.append((mat_check, mat))
                         mat_lyt.addWidget(mat_check)
-                    checkBoxNone = QPushButton("Select None")
+                    checkBoxNone = QPushButton("Deselect All")
                     checkBoxNone.clicked.connect(self.deselctAllMaterials)
                     mat_lyt.addWidget(checkBoxNone, 0, 0)
                     checkBoxAll = QPushButton("Select All")
@@ -738,8 +741,9 @@ class RenderManForSP(object):
                         config['exportParameters'][0]['parameters']['sizeLog2'] = self.res_override
                     # make sure each texture set only exports existing channels.
                     config['exportList'] = []
+                    tset_list = [matPair[1] for matPair in self.opt_tsets if matPair[0].checkState()] 
                     # find all requested channels
-                    for tset in spts.all_texture_sets():
+                    for tset in tset_list:
                         channels = set()
                         tset_settings = {'rootPath': tset.name(),
                                          'filter': {'outputMaps': []}}

--- a/plugin/renderman_for_sp.py
+++ b/plugin/renderman_for_sp.py
@@ -317,6 +317,15 @@ class RenderManForSP(object):
                         'exportMaterial: %r, %r, %r', categorypath, infodict,
                         previewtype)
                     # get specific Substance painter options
+
+                    # list of spts.TextureSet objects
+                    # all texture sets who have a selected checkbox
+                    tset_list = [matPair[1] for matPair in self.opt_tsets if matPair[0].checkState()] 
+
+                    if (len(tset_list) <= 0):
+                        LOG.info('RenderMan : No texture sets selected')
+                        return False
+                    
                     # exported bxdf
                     _preset = self.opt_bxdf.currentText()
                     self.prefsobj.set('last preset', _preset)
@@ -349,13 +358,6 @@ class RenderManForSP(object):
                     self.spx_progress.setAutoClose(True)
                     QApplication.processEvents()
 
-                    # list of spts.TextureSet objects
-                    # all texture sets who have a selected checkbox
-                    tset_list = [matPair[1] for matPair in self.opt_tsets if matPair[0].checkState()] 
-
-                    if (len(tset_list) <= 0):
-                        LOG.info('RenderMan : No texture sets selected')
-                        return True
                     # build assets
                     for mat in tset_list:
                         if self.spx_progress.wasCanceled():


### PR DESCRIPTION
By default the plugin exports every texture set whenever it is run. 

Added a set of checkboxes to control which texture sets get exported.
<img width="407" alt="image" src="https://user-images.githubusercontent.com/60642573/216810642-13a752f2-7f9c-467f-87d6-7d37823147ec.png">

Defaults to all selected, so the default behavior is the same as before.
Includes Select All / Deselect All buttons for ease of use.
In a scrollable UI element, so it handles window resizing or large numbers of texture sets well.
 